### PR TITLE
add docker image for linux musl

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-musl]
+linker = "rust-lld"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+COPY target/x86_64-unknown-linux-musl/release/configur /configur
+ENTRYPOINT ["/configur"]
+CMD ["--help"]


### PR DESCRIPTION
This allows building on Windows with Docker for Windows. This should work on other platforms.

rustup target add x86_64-unknown-linux-musl
cargo build --release --target=x86_64-unknown-linux-musl
docker buildx build . -t myacr.azurecr.io/configur