### PR TITLE
add wasm.Dockerfile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,14 +20,20 @@ enum Commands {
 }
 
 fn list_yml_files(source: &Utf8Path) -> Vec<Utf8PathBuf> {
+    let exists = source.exists();
+    println!("source: {source}, exists: {exists}");
     let source = source.to_string();
     let mut files = Vec::new();
-    if let Ok(paths) = glob(&format!("{source}/**/*.yml")) {
-        for path in paths.flatten() {
-            if let Ok(path) = Utf8PathBuf::from_path_buf(path) {
-                files.push(path);
+    match glob(&format!("{source}/**/*.yml")) {
+        Ok(paths) => {
+            for path in paths.flatten() {
+                match Utf8PathBuf::from_path_buf(path) {
+                    Ok(path) => files.push(path),
+                    Err(e) => println!("{:?}", e),
+                }
             }
         }
+        Err(e) => println!("{:?}", e),
     }
     files
 }

--- a/wasm.Dockerfile
+++ b/wasm.Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+COPY target/wasm32-wasi/release/configur.wasm /configur.wasm
+ENTRYPOINT ["/configur.wasm"]
+CMD ["--help"]


### PR DESCRIPTION
Here is how to build and run using Wasmtime https://wasmtime.dev/ and Docker https://docs.docker.com/desktop/wasm/ .  Since it is I/O bound, it takes 24 seconds on Docker for Windows and 1.6 seconds under Wasmtime.

```
cargo install cargo-wasi
cargo wasi build --release
```

```
winget install BytecodeAlliance.Wasmtime
wasmtime run --dir $EV2 target\wasm32-wasi\release\configur.wasm -- config $EV2/environments $EV2/scratch
```

```
docker buildx build --platform wasi/wasm --provenance=false -f wasm.Dockerfile -t $REGISTRY/cataggar/configur.wasm .
```
Due to [bug](https://github.com/docker/roadmap/issues/426#issuecomment-1609837552), `--provenance=false` is temporarily required.

```
docker run --platform=wasi/wasm --runtime=io.containerd.wasmtime.v1 --rm -v ${EV2}:/ev2 $REGISTRY/cataggar/configur.wasm config /ev2/environments /ev2/scratch
```