### PR TITLE
add Jinga template support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "clap",
  "dep-graph",
  "glob",
+ "ipnet",
  "minijinja",
  "serde_json",
  "serde_json_merge",
@@ -349,6 +350,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -168,6 +174,7 @@ dependencies = [
  "anyhow",
  "camino",
  "clap",
+ "dep-graph",
  "glob",
  "minijinja",
  "serde_json",
@@ -177,12 +184,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.16",
 ]
 
 [[package]]
@@ -191,9 +208,9 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.16",
 ]
 
 [[package]]
@@ -203,10 +220,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.16",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
 ]
 
 [[package]]
@@ -215,7 +243,18 @@ version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "dep-graph"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6bb4227b85b5ca531b2a6404c9d5122028c7de2f5bea3e3000e07215ec28376"
+dependencies = [
+ "crossbeam-channel 0.4.4",
+ "num_cpus",
+ "rayon",
 ]
 
 [[package]]
@@ -347,6 +386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,9 +483,9 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.5.8",
  "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.16",
  "num_cpus",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "camino",
  "clap",
  "glob",
+ "minijinja",
  "serde_json",
  "serde_json_merge",
  "serde_yaml",
@@ -358,6 +359,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minijinja"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c43c912b380856deeb78d826e3b77df13a90e69aef6223e3ad28c02d2ca857"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ camino = "1.1.6"
 clap = { version = "4.3.23", features = ["derive"] }
 dep-graph = "0.2.0"
 glob = "0.3.1"
+ipnet = "2.8.0"
 minijinja = "1.0.7"
 serde_json = "1.0.105"
 serde_json_merge = { version = "0.0.4", features = ["merge", "sort"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.75"
 camino = "1.1.6"
 clap = { version = "4.3.23", features = ["derive"] }
 glob = "0.3.1"
+minijinja = "1.0.7"
 serde_json = "1.0.105"
 serde_json_merge = { version = "0.0.4", features = ["merge", "sort"] }
 serde_yaml = "0.9.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0.75"
 camino = "1.1.6"
 clap = { version = "4.3.23", features = ["derive"] }
+dep-graph = "0.2.0"
 glob = "0.3.1"
 minijinja = "1.0.7"
 serde_json = "1.0.105"

--- a/pack.nu
+++ b/pack.nu
@@ -1,0 +1,2 @@
+cargo wasi build --release
+npm pack

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cataggar/configur",
-    "version": "0.1.8",
+    "version": "0.2.0",
     "description": "transforms configuration files",
     "main": "main.js",
     "type": "module",

--- a/src/jinga.rs
+++ b/src/jinga.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use minijinja::{Environment, Value};
+
+fn nthhost_filter(value: String, n: i32) -> String {
+    println!("nthhost_filter {value} {n}");
+    format!("{value}{n}")
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use minijinja::context;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_remove_brackets() -> Result<()> {
+        // let expr_str = "aks_static_services_subnet | string | nthhost(7)";
+        // let expr_str = "'aks static services subnet' | string | nthhost(7)";
+        // let expr_str = "1 + 4";
+
+        let tmpl_str = "{{aks_static_services_subnet | nthhost(7)}}";
+
+        BTreeMap::from_iter(vec![(1, 2), (3, 4)]);
+
+        let mut variables = BTreeMap::new();
+        variables.insert("aks_static_services_subnet", "100.73.5.0/24");
+        let ctx = Value::from(variables);
+
+        let mut env = Environment::new();
+        // env.add_filter("string", string_filter);
+        env.add_filter("nthhost", nthhost_filter);
+        env.set_debug(true);
+
+        // let expr = env.compile_expression(expr_str)?;
+        // let result = expr.eval()?;
+
+        let tmpl = env.template_from_str(tmpl_str)?;
+        let (rv, _state) = tmpl.render_and_return_state(ctx)?;
+
+        let serialized = serde_json::to_string_pretty(&rv)?;
+        println!("serialized {serialized}");
+
+        Ok(())
+    }
+}

--- a/src/jinga.rs
+++ b/src/jinga.rs
@@ -1,5 +1,97 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use minijinja::{Environment, Value};
+use serde_json_merge::Dfs;
+use serde_json_merge::Iter;
+use dep_graph::{DepGraph, Node};
+
+// implement default
+#[derive(Default)]
+struct VarNodes {
+    named_nodes: HashMap<String, Node<String>>,
+}
+
+impl VarNodes {
+    /// get or create node with name
+    fn get_or_create(&mut self, name: &str) -> &mut Node<String> {
+        if !self.named_nodes.contains_key((name)){
+            let node = Node::new(name.to_string());
+            self.named_nodes.insert(name.to_string(), node);
+        }
+        self.named_nodes.get_mut(name).unwrap()
+    }
+    fn add_dep(&mut self, source: &str, target: &str) {
+        let source_node = self.get_or_create(source);
+        source_node.add_dep(target.to_string());
+    }
+    fn graph(self) -> DepGraph<String> {
+        let nodes = self.named_nodes.into_values().collect::<Vec<_>>();
+        DepGraph::new(&nodes)
+    }
+}
+
+/// Renders any values that are jinja templates.
+/// The keys are set as global varaibles.
+pub fn render(value: &mut serde_json::Value) -> Result<()> {
+
+    let mut env = Environment::new();
+    env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+
+    // let mut template_strings = Vec::new();
+    
+
+    // build graph of variables
+    // let mut var_node: HashMap<String, Node<String>> = HashMap::new();
+    // let mut variables: Vec<Node<String>> = Vec::new();
+    let mut var_nodes = VarNodes::default();
+    value.iter_recursive::<Dfs>().for_each(|(path, value)| {
+        if let Some(value) = value.as_str() {
+
+            // all root keys are variables
+            // if let Some(root_key) = root_node {
+            //     variables.push(variable);
+            // }
+            // if the value is a template
+            if value.contains("{{") {
+                let root_var: Option<String> = 
+                if path.depth() == 1 {
+                    Some(path.last().unwrap().to_string())
+                } else {
+                    None
+                };
+                if let Ok(tmpl) = env.template_from_str(value) {
+                    let vars = tmpl.undeclared_variables(false);
+                    for var in &vars {
+                        if let Some(root_var) = &root_var {
+                            var_nodes.add_dep(root_var, var)
+                        }
+                        var_nodes.get_or_create(var);
+                    }
+                }
+            }
+        }
+    });
+
+    // let graph = DepGraph::new(&variables);
+    let graph = var_nodes.graph();
+    graph
+        .into_iter()
+        .for_each(|node| {
+            println!("{:?}", node)
+        });
+
+    // value
+    //     .mutate_recursive::<Dfs>()
+    //     .for_each(|_, val: &mut Value| {
+    //         if let Some(obj) = val.as_object_mut() {
+    //             if let Some(removed) = obj.remove("<<") {
+    //                 val.merge_recursive::<Dfs>(&removed);
+    //             }
+    //         }
+    //     });
+    Ok(())
+}
 
 fn nthhost_filter(value: String, n: i32) -> String {
     println!("nthhost_filter {value} {n}");
@@ -9,7 +101,7 @@ fn nthhost_filter(value: String, n: i32) -> String {
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use minijinja::context;
+    use minijinja::{context, UndefinedBehavior};
     use std::collections::BTreeMap;
 
     #[test]
@@ -22,20 +114,36 @@ pub mod test {
 
         BTreeMap::from_iter(vec![(1, 2), (3, 4)]);
 
-        let mut variables = BTreeMap::new();
-        variables.insert("aks_static_services_subnet", "100.73.5.0/24");
-        let ctx = Value::from(variables);
+        // let mut variables = BTreeMap::new();
+        // variables.insert("aks_static_services_subnet", "100.73.5.0/24");
+        // let ctx = Value::from(variables);
 
         let mut env = Environment::new();
         // env.add_filter("string", string_filter);
         env.add_filter("nthhost", nthhost_filter);
         env.set_debug(true);
+        env.set_undefined_behavior(UndefinedBehavior::Strict);
+        env.add_global("aks_static_services_subnet", "100.73.5.0/24");
+        env.add_global("host", "abc");
 
         // let expr = env.compile_expression(expr_str)?;
         // let result = expr.eval()?;
 
-        let tmpl = env.template_from_str(tmpl_str)?;
-        let (rv, _state) = tmpl.render_and_return_state(ctx)?;
+        // let tmpl = env.template_from_str(tmpl_str)?;
+
+        let _tmpl_host = env.template_from_named_str("host", "{{aks_static_services_subnet | nthhost(7)}}")?;
+
+        
+
+        let tmpl_host2 = env.template_from_named_str("host2", "{{ host | nthhost(7)}}")?;
+        let variables = tmpl_host2.undeclared_variables(false);
+        println!("variables {variables:?}");
+        
+
+        // let (rv, _state) = tmpl_host2.render_and_return_state(ctx)?;
+        let ctx = Value::default();
+        let rv = tmpl_host2.render(ctx)?;
+        println!("rv {rv}");
 
         let serialized = serde_json::to_string_pretty(&rv)?;
         println!("serialized {serialized}");

--- a/src/jinga.rs
+++ b/src/jinga.rs
@@ -11,7 +11,6 @@ use serde_json_merge::Dfs;
 use serde_json_merge::Iter;
 use std::str::FromStr;
 
-// implement default
 #[derive(Default)]
 struct VarNodes {
     named_nodes: HashMap<String, Node<String>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,9 @@ fn main() -> Result<()> {
         }
 
         dump_json.sort_keys_recursive::<Dfs>();
+
+        jinga::render(&mut dump_json)?;
+
         let dir = dump_json_path
             .parent()
             .with_context(|| "parent of {dump_json_path}")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ use serde_json_merge::SortKeys;
 use std::collections::HashMap;
 use std::{collections::BTreeMap, fs, str::FromStr};
 
+mod jinga;
+
 type JsonCache = HashMap<Utf8PathBuf, Value>;
 
 #[derive(Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,12 @@ fn main() -> Result<()> {
 
         dump_json.sort_keys_recursive::<Dfs>();
 
-        jinga::render(&mut dump_json)?;
+        match jinga::render(&mut dump_json) {
+            Ok(_) => {}
+            Err(_err) => {
+                // println!("render error: {err}");
+            }
+        }
 
         let dir = dump_json_path
             .parent()


### PR DESCRIPTION
Adds Jinga support for configuration. The top level configuration settings are added as global variables. The graph of the template variables are calculated to figure out the right order to render them. This adds Jinga filters of `string` and `nthhost` with unit tests. They are just standard functions in Rust.